### PR TITLE
Adds helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Docker images used within scalableminds :whale:
 ## Images
 
 * [cronut](cronut)
+* [fluentd](fluentd)
+* [helm](helm)

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.6
+
+ENV HELM_VERSION="v2.9.0"
+
+RUN apk add --no-cache bash ca-certificates coreutils curl findutils grep git python3 wget \
+    && pip3 install aiohttp github-webhook pyyaml 'ruamel.yaml<=0.15' slackweb \
+    && wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -xvf helm-${HELM_VERSION}-linux-amd64.tar.gz linux-amd64/helm \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf linux-amd64 \
+    && rm -f /helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && chmod +x /usr/local/bin/helm
+
+RUN helm version --client
+RUN helm init -c
+RUN helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+
+ENTRYPOINT ["helm"]

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,2 @@
+# docker-helm
+Simple docker image for helm

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,2 +1,0 @@
-# docker-helm
-Simple docker image for helm


### PR DESCRIPTION
Makes https://github.com/scalableminds/docker-helm unnecessary which we'd otherwise need to upgrade to CircleCI 2.