### PR TITLE
kubectl: use curl instead of ADD

### DIFF
--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -2,10 +2,13 @@ FROM alpine:3.6
 
 ENV KUBE_VERSION="v1.7.5"
 
-ADD https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+RUN apk --no-cache add --virtual build curl && \
+    curl -Ls -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl && \
+    apk del build
 
-RUN apk add --no-cache bash ca-certificates coreutils findutils && \
-    chmod +x /usr/local/bin/kubectl
+RUN apk add --no-cache bash ca-certificates coreutils findutils
+
+RUN chmod +x /usr/local/bin/kubectl
 
 RUN kubectl version --client
 


### PR DESCRIPTION
using `RUN curl` instead of `ADD` allows to reuse the cache. Currently we don't use the cache in the CI, but it helps locally already.