### PR TITLE
sbt: set sbt.global.base to /root/.sbt/0.13

### DIFF
--- a/sbt/Dockerfile
+++ b/sbt/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jdk
 
 ARG VERSION_SBT="0.13.17"
+ARG VERSION_SBT_MINOR="0.13"
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -14,6 +15,6 @@ RUN mkdir /app && chmod 777 /app
 WORKDIR /app/
 
 # allowing to specify a random user via docker:
-ENV SBT_OPTS "-Dsbt.global.base=/root/.sbt/${VERSION_SBT%.*}  -Dsbt.ivy.home=/root/.ivy2/  -Divy.home=/root/.ivy2/"
+ENV SBT_OPTS "-Dsbt.global.base=/root/.sbt/${VERSION_SBT_MINOR}  -Dsbt.ivy.home=/root/.ivy2/  -Divy.home=/root/.ivy2/"
 RUN sbt sbtVersion # adding sbt to the cache
 RUN chmod -R 777 /root

--- a/sbt/Dockerfile
+++ b/sbt/Dockerfile
@@ -14,6 +14,6 @@ RUN mkdir /app && chmod 777 /app
 WORKDIR /app/
 
 # allowing to specify a random user via docker:
-ENV SBT_OPTS '-Dsbt.global.base=/root/.sbt/  -Dsbt.ivy.home=/root/.ivy2/  -Divy.home=/root/.ivy2/'
+ENV SBT_OPTS "-Dsbt.global.base=/root/.sbt/${VERSION_SBT%.*}  -Dsbt.ivy.home=/root/.ivy2/  -Divy.home=/root/.ivy2/"
 RUN sbt sbtVersion # adding sbt to the cache
 RUN chmod -R 777 /root


### PR DESCRIPTION
The global sbt folder was configured one directory to high, according to https://www.scala-sbt.org/0.13/docs/Command-Line-Reference.html
This fixes it (see also https://github.com/scalableminds/webknossos/pull/2849)