### PR TITLE
Install stable chrome for puppeteer

### DIFF
--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y wget gnupg curl \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     && apt-get install -y git ssh-client \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
See https://github.com/puppeteer/puppeteer/pull/6267/files and https://github.com/scalableminds/dockerfiles/pull/19