### PR TITLE
Add b2 python package to duply

### DIFF
--- a/duply/Dockerfile
+++ b/duply/Dockerfile
@@ -11,6 +11,7 @@ RUN  apt-get update \
       openssh-client \
       pwgen \
       python-boto \
+      python-pip \
       rsync \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/duply/Dockerfile
+++ b/duply/Dockerfile
@@ -15,7 +15,7 @@ RUN  apt-get update \
       rsync \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && pip install b2
+  && pip install b2==3.1.0
 
 RUN mkdir -p /root/.duply/project
 COPY conf.template /root/.duply/project/conf.template

--- a/duply/Dockerfile
+++ b/duply/Dockerfile
@@ -13,7 +13,8 @@ RUN  apt-get update \
       python-boto \
       rsync \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && pip install b2
 
 RUN mkdir -p /root/.duply/project
 COPY conf.template /root/.duply/project/conf.template


### PR DESCRIPTION
The backup crashed because of that this morning:
```
2021-12-08T04:07:22.371873081+01:00 stdout F BackendException: B2 backend requires B2 Python APIs (pip install b2)
```