### PR TITLE
Upgrade slurm image

### DIFF
--- a/slurm-docker-cluster/Dockerfile
+++ b/slurm-docker-cluster/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM rockylinux:8.5
 
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
@@ -13,9 +13,8 @@ ARG SLURM_TAG=slurm-19-05-1-2
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \
-    && yum makecache fast \
+    && yum makecache \
     && yum -y update \
-    && yum -y install epel-release \
     && yum -y install \
        wget \
        bzip2 \
@@ -26,19 +25,17 @@ RUN set -ex \
        gnupg \
        make \
        munge \
-       munge-devel \
-       python-devel \
-       python-pip \
-       python3 \
-       python3-devel \
-       python3-pip \
+       python38 \
+       python38-devel \
+       python38-pip \
        mariadb-server \
        mariadb-devel \
        psmisc \
        bash-completion \
        vim-enhanced \
     && yum clean all \
-    && rm -rf /var/cache/yum
+    && rm -rf /var/cache/yum \
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python3 -m pip install --upgrade pip
 
@@ -73,8 +70,8 @@ RUN set -x \
     && install -D -m644 contribs/slurm_completion_help/slurm_completion.sh /etc/profile.d/slurm_completion.sh \
     && popd \
     && rm -rf slurm \
-    && groupadd -r --gid=995 slurm \
-    && useradd -r -g slurm --uid=995 slurm \
+    && groupadd -r --gid=994 slurm \
+    && useradd -r -g slurm --uid=994 slurm \
     && mkdir /etc/sysconfig/slurm \
         /var/spool/slurmd \
         /var/run/slurmd \

--- a/slurm-docker-cluster/Dockerfile
+++ b/slurm-docker-cluster/Dockerfile
@@ -15,6 +15,7 @@ ARG GOSU_VERSION=1.11
 RUN set -ex \
     && yum makecache \
     && yum -y update \
+    && yum -y install epel-release \
     && yum -y install \
        wget \
        bzip2 \
@@ -25,6 +26,7 @@ RUN set -ex \
        gnupg \
        make \
        munge \
+       munge-devel \
        python38 \
        python38-devel \
        python38-pip \

--- a/slurm-docker-cluster/Dockerfile
+++ b/slurm-docker-cluster/Dockerfile
@@ -13,10 +13,12 @@ ARG SLURM_TAG=slurm-19-05-1-2
 ARG GOSU_VERSION=1.11
 
 RUN set -ex \
-    && yum makecache \
-    && yum -y update \
-    && yum -y install epel-release \
-    && yum -y install \
+    && dnf makecache \
+    && dnf -y update \
+    && dnf -y install dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf config-manager --enable epel \
+    && dnf config-manager --set-enabled powertools \
+    && dnf -y install \
        wget \
        bzip2 \
        perl \
@@ -35,7 +37,7 @@ RUN set -ex \
        psmisc \
        bash-completion \
        vim-enhanced \
-    && yum clean all \
+    && dnf clean all \
     && rm -rf /var/cache/yum \
     && ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
Upgrades slurm image to Rocky Linux 8.5 (centos ahas been discontinued) for Python 3.8 support.
Seems to work: https://github.com/scalableminds/webknossos-libs/runs/5624749973?check_suite_focus=true