### PR TITLE
Update Puppeteer Dockerfile to use node v18

### DIFF
--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:18-slim
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Update Puppeteer Dockerfile to use node v18. WK Tests require node v18 now.