### PR TITLE
Fix WK nightly tests

### DIFF
--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -5,13 +5,13 @@ WORKDIR /usr/app
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
 # Inspired by https://gist.github.com/navarroaxel/3f44927c9a3e28c25a2b30c244813e07
-RUN apt-get update && apt-get install curl gnupg nodejs -y \
-  && curl --location --silent https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install google-chrome-stable -y --no-install-recommends \
-  && apt-get install -y git ssh-client --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install curl gnupg -y \
+#   && curl --location --silent https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+#   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+#   && apt-get update \
+#   && apt-get install google-chrome-stable -y --no-install-recommends \
+#   && apt-get install -y git ssh-client --no-install-recommends \
+#   && rm -rf /var/lib/apt/lists/*
 
 # It's a good idea to use dumb-init to help prevent zombie chrome processes.
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM debian:bookworm-slim
 
 WORKDIR /usr/app
 
@@ -6,7 +6,7 @@ WORKDIR /usr/app
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
 # Inspired by https://gist.github.com/navarroaxel/3f44927c9a3e28c25a2b30c244813e07
-RUN apt-get update && apt-get install curl gnupg -y \
+RUN apt-get update && apt-get install curl gnupg nodejs -y \
   && curl --location --silent https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
@@ -24,7 +24,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Enable corepack so that yarn can downloaded/installed during the CI run.
-RUN corepack enable && corepack install -g yarn@^4.4.1
+RUN corepack enable
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,5 +1,6 @@
 FROM cimg/node:18.20-browsers
 WORKDIR /usr/app
+USER root
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -24,8 +24,8 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Install puppeteer so it's available in the container.
-RUN corepack enable
-RUN yarn install puppeteer
+RUN corepack enable && corepack install -g yarn@^4.4.1
+RUN yarn add puppeteer@^19.7.2
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -2,6 +2,10 @@ FROM node:18-slim
 
 WORKDIR /usr/app
 
+# Override the default yarn v1.22 version as shipped by the baseline node:18-slim image
+ENV YARN_VERSION 4.4.1
+RUN yarn policies set-version $YARN_VERSION
+
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -24,7 +24,8 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Install puppeteer so it's available in the container.
-RUN npm i puppeteer
+RUN corepack enable && corepack install yarn
+RUN yarn install puppeteer
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -2,10 +2,6 @@ FROM node:18-slim
 
 WORKDIR /usr/app
 
-# Override the default yarn v1.22 version as shipped by the baseline node:18-slim image
-ENV YARN_VERSION 4.4.1
-RUN yarn policies set-version $YARN_VERSION
-
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
@@ -28,7 +24,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Enable corepack so that yarn can downloaded/installed during the CI run.
-RUN corepack enable
+RUN corepack enable && corepack install -g yarn@^4.4.1
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -2,6 +2,9 @@ FROM cimg/node:18.20-browsers
 WORKDIR /usr/app
 USER root
 
+# Remove any existing pre-installed yarn binary. 
+RUN rm -r /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
+
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
@@ -24,7 +27,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Enable corepack so that yarn can downloaded/installed during the CI run.
-RUN corepack enable yarn
+RUN corepack enable
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:bookworm-slim
-
+FROM cimg/node:18.20-browsers
 WORKDIR /usr/app
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
@@ -24,7 +23,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Enable corepack so that yarn can downloaded/installed during the CI run.
-RUN corepack enable
+RUN corepack enable yarn
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -23,15 +23,14 @@ RUN chmod +x /usr/local/bin/dumb-init
 #     browser.launch({executablePath: 'google-chrome-unstable'})
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-# Install puppeteer so it's available in the container.
-RUN corepack enable && corepack install -g yarn@^4.4.1
-RUN yarn add puppeteer@^19.7.2
+# Enable corepack so that yarn can downloaded/installed during the CI run.
+RUN corepack enable
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && mkdir -p /home/pptruser/Downloads \
     && chown -R pptruser:pptruser /home/pptruser \
-    && chown -R pptruser:pptruser /usr/app/node_modules
+    && chown -R pptruser:pptruser /usr/app
 
 # Run everything after as non-privileged user.
 USER pptruser

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 # Install puppeteer so it's available in the container.
-RUN corepack enable && corepack install yarn
+RUN corepack enable
 RUN yarn install puppeteer
 
 # Add user so we don't need --no-sandbox.


### PR DESCRIPTION
The WK nightly tests [[0](https://app.circleci.com/pipelines/github/scalableminds/webknossos/18697/workflows/db91a810-5d18-4932-af5d-0174a896ef9a)][[1](https://app.circleci.com/pipelines/github/scalableminds/webknossos/18695/workflows/f07ed817-ea47-4938-ad61-f62262e4f003)] fail regularly. Looking at the CLI output it looks like it is still using yarn v1. Further, in the Dockerfile `puppeteer` is installed with `npm` and in our CI workflow other dependencies are installed with `yarn`.

I propose the only use `yarn` as a JS depenedency manager in the Dockerfile and ensure that version 4.4 is used. Hopefully that fixes the nightly tests. 

See also this Slack conversation: https://scm.slack.com/archives/C3RUHRXBM/p1729147775334849
